### PR TITLE
Switch timestamp format

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You need to run at least nginx version 1.11.8, escaped JSON support.
 
 **Add this to your nginx configuration and restart the service:**
 
-    log_format graylog2_json escape=json '{ "timestamp": "$time_iso8601", '
+    log_format graylog2_json escape=json '{ "timestamp": "$msec", '
                  '"remote_addr": "$remote_addr", '
                  '"body_bytes_sent": $body_bytes_sent, '
                  '"request_time": $request_time, '


### PR DESCRIPTION
According to [the docs](http://docs.graylog.org/en/3.0/pages/gelf.html) the `timestamp` field should be a number. The nginx variable `$msec` will return "current time in seconds with the milliseconds resolution".

This will resolve seeing log messages like the following:

```
2019-04-29 13:37:22,175 WARN : org.graylog2.inputs.codecs.GelfCodec - GELF message <71bb28f0-6aa5-11e9-97ac-0242ac140005> (received from <IP>) has invalid "timestamp": 2019-04-29T13:37:15.4186353-04:00  (type: STRING)
```